### PR TITLE
feat(shared_memory): add SetInterVMMemoryProvider for inter-VM shm su…

### DIFF
--- a/score/memory/shared/shared_memory_factory.cpp
+++ b/score/memory/shared/shared_memory_factory.cpp
@@ -85,6 +85,11 @@ auto SharedMemoryFactory::SetTypedMemoryProvider(std::shared_ptr<TypedMemory> ty
     instance().SetTypedMemoryProvider(typed_memory_ptr);
 }
 
+auto SharedMemoryFactory::SetInterVMMemoryProvider(std::shared_ptr<TypedMemory> intervm_memory_ptr) noexcept -> void
+{
+    static_cast<SharedMemoryFactoryImpl&>(instance()).SetInterVMMemoryProvider(intervm_memory_ptr);
+}
+
 auto SharedMemoryFactory::instance() noexcept -> ISharedMemoryFactory&
 {
     if (mock_ != nullptr)

--- a/score/memory/shared/shared_memory_factory.h
+++ b/score/memory/shared/shared_memory_factory.h
@@ -160,6 +160,8 @@ class SharedMemoryFactory
 
     static void SetTypedMemoryProvider(std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr) noexcept;
 
+    static void SetInterVMMemoryProvider(std::shared_ptr<score::memory::shared::TypedMemory> intervm_memory_ptr) noexcept;
+
     static std::size_t GetControlBlockSize() noexcept
     {
         return instance().GetControlBlockSize();

--- a/score/memory/shared/shared_memory_factory_impl.cpp
+++ b/score/memory/shared/shared_memory_factory_impl.cpp
@@ -139,18 +139,23 @@ auto SharedMemoryFactoryImpl::Open(const std::string& path,
 {
     if (IsInterVmShmPath(path))
     {
-        score::mw::log::LogError("shm") << "Opening inter-VM shared memory (path prefix '" << kInterVmSharedShmPrefix
-                                      << "') is not supported. No portable implementation exists yet. Rejecting path: "
-                                      << path;
-        return nullptr;
+        if (intervm_memory_ptr_ == nullptr)
+        {
+            score::mw::log::LogError("shm")
+                << "Opening inter-VM shared memory (path prefix '" << kInterVmSharedShmPrefix
+                << "') requires an InterVM memory provider set via SetInterVMMemoryProvider(). Rejecting path: "
+                << path;
+            return nullptr;
+        }
     }
 
     std::lock_guard<std::mutex> lock{mutex_};
     auto resource = GetResourceIfAlreadyOpened(path, resources_);
     if (resource == nullptr)
     {
+        const auto effective_ptr = IsInterVmShmPath(path) ? intervm_memory_ptr_ : typed_memory_ptr_;
         const auto result =
-            SharedMemoryResource::Open(path, is_read_write, &CreateAccessControlList, typed_memory_ptr_);
+            SharedMemoryResource::Open(path, is_read_write, &CreateAccessControlList, effective_ptr);
         if (!result.has_value())
         {
             score::mw::log::LogWarn("shm") << "Could not open Shared Memory " << path << ":" << result.error();
@@ -184,10 +189,14 @@ auto score::memory::shared::SharedMemoryFactoryImpl::Create(std::string path,
 {
     if (IsInterVmShmPath(path))
     {
-        score::mw::log::LogError("shm") << "Creating inter-VM shared memory (path prefix '" << kInterVmSharedShmPrefix
-                                      << "') is not supported. No portable implementation exists yet. Rejecting path: "
-                                      << path;
-        return nullptr;
+        if (intervm_memory_ptr_ == nullptr)
+        {
+            score::mw::log::LogError("shm")
+                << "Creating inter-VM shared memory (path prefix '" << kInterVmSharedShmPrefix
+                << "') requires an InterVM memory provider set via SetInterVMMemoryProvider(). Rejecting path: "
+                << path;
+            return nullptr;
+        }
     }
 
     std::lock_guard<std::mutex> lock{mutex_};
@@ -197,17 +206,27 @@ auto score::memory::shared::SharedMemoryFactoryImpl::Create(std::string path,
         return nullptr;
     }
 
-    if (prefer_typed_memory && (typed_memory_ptr_ == nullptr))
+    // Determine which provider to use: inter-VM paths use the InterVM provider,
+    // otherwise fall back to the typed memory provider if prefer_typed_memory is set.
+    std::shared_ptr<TypedMemory> effective_provider = nullptr;
+    if (IsInterVmShmPath(path))
     {
-        score::mw::log::LogError("shm")
-            << "Shared memory has to be created in typed memory but no typed memory instance has "
-               "been provided using the public interface SetTypedMemoryProvider ";
-        return nullptr;
+        effective_provider = intervm_memory_ptr_;
+    }
+    else if (prefer_typed_memory)
+    {
+        if (typed_memory_ptr_ == nullptr)
+        {
+            score::mw::log::LogError("shm")
+                << "Shared memory has to be created in typed memory but no typed memory instance has "
+                   "been provided using the public interface SetTypedMemoryProvider ";
+            return nullptr;
+        }
+        effective_provider = typed_memory_ptr_;
     }
 
-    const auto typed_memory_ptr = prefer_typed_memory ? typed_memory_ptr_ : nullptr;
     const auto result = SharedMemoryResource::Create(
-        path, user_space_to_reserve, std::move(cb), permissions, &CreateAccessControlList, typed_memory_ptr);
+        path, user_space_to_reserve, std::move(cb), permissions, &CreateAccessControlList, effective_provider);
     if (!result.has_value())
     {
         score::mw::log::LogWarn("shm") << "Could not create Shared Memory " << path << ":" << result.error();
@@ -264,32 +283,43 @@ auto score::memory::shared::SharedMemoryFactoryImpl::CreateOrOpen(
 {
     if (IsInterVmShmPath(path))
     {
-        score::mw::log::LogError("shm") << "Creating or opening inter-VM shared memory (path prefix '"
-                                      << kInterVmSharedShmPrefix
-                                      << "') is not supported. No portable implementation exists yet. Rejecting path: "
-                                      << path;
-        return nullptr;
+        if (intervm_memory_ptr_ == nullptr)
+        {
+            score::mw::log::LogError("shm")
+                << "Creating or opening inter-VM shared memory (path prefix '" << kInterVmSharedShmPrefix
+                << "') requires an InterVM memory provider set via SetInterVMMemoryProvider(). Rejecting path: "
+                << path;
+            return nullptr;
+        }
     }
 
     std::lock_guard<std::mutex> lock{mutex_};
     auto resource = GetResourceIfAlreadyOpened(path, resources_);
     if (resource == nullptr)
     {
-        if ((prefer_typed_memory) && (typed_memory_ptr_ == nullptr))
+        std::shared_ptr<TypedMemory> effective_provider = nullptr;
+        if (IsInterVmShmPath(path))
         {
-            score::mw::log::LogError("shm")
-                << "Shared memory has to be created in typed memory but no typed memory instance "
-                   "has been provided using the public interface SetTypedMemoryProvider ";
-            return nullptr;
+            effective_provider = intervm_memory_ptr_;
+        }
+        else if (prefer_typed_memory)
+        {
+            if (typed_memory_ptr_ == nullptr)
+            {
+                score::mw::log::LogError("shm")
+                    << "Shared memory has to be created in typed memory but no typed memory instance "
+                       "has been provided using the public interface SetTypedMemoryProvider ";
+                return nullptr;
+            }
+            effective_provider = typed_memory_ptr_;
         }
 
-        const auto typed_memory_ptr = prefer_typed_memory ? typed_memory_ptr_ : nullptr;
         const auto result = SharedMemoryResource::CreateOrOpen(path,
                                                                user_space_to_reserve,
                                                                std::move(cb),
                                                                access_control.permissions_,
                                                                &CreateAccessControlList,
-                                                               typed_memory_ptr);
+                                                               effective_provider);
         if (!result.has_value())
         {
             score::mw::log::LogWarn("shm") << __func__ << __LINE__ << "Could not create or open Shared Memory " << path
@@ -380,6 +410,11 @@ auto SharedMemoryFactoryImpl::RemoveStaleArtefacts(const std::string& path) noex
 auto SharedMemoryFactoryImpl::SetTypedMemoryProvider(std::shared_ptr<TypedMemory> typed_memory_ptr) noexcept -> void
 {
     typed_memory_ptr_ = typed_memory_ptr;
+}
+
+auto SharedMemoryFactoryImpl::SetInterVMMemoryProvider(std::shared_ptr<TypedMemory> intervm_memory_ptr) noexcept -> void
+{
+    intervm_memory_ptr_ = intervm_memory_ptr;
 }
 
 }  // namespace score::memory::shared

--- a/score/memory/shared/shared_memory_factory_impl.h
+++ b/score/memory/shared/shared_memory_factory_impl.h
@@ -59,6 +59,8 @@ class SharedMemoryFactoryImpl final : public ISharedMemoryFactory
 
     void SetTypedMemoryProvider(std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr) noexcept override;
 
+    void SetInterVMMemoryProvider(std::shared_ptr<score::memory::shared::TypedMemory> intervm_memory_ptr) noexcept;
+
     std::size_t GetControlBlockSize() noexcept override
     {
         return sizeof(score::memory::shared::SharedMemoryResource::ControlBlock);
@@ -73,6 +75,7 @@ class SharedMemoryFactoryImpl final : public ISharedMemoryFactory
     std::mutex mutex_{};
     std::unordered_map<std::string, std::weak_ptr<score::memory::shared::SharedMemoryResource>> resources_{};
     std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr_{memory::shared::TypedMemory::Default()};
+    std::shared_ptr<score::memory::shared::TypedMemory> intervm_memory_ptr_{nullptr};
 };
 
 }  // namespace score::memory::shared


### PR DESCRIPTION
…pport

Add a separate InterVM memory provider that is used when the shm path has the inter-VM prefix (/intervm-shared-shmem/). This replaces the previous hard rejection of inter-VM paths in Create/Open/CreateOrOpen with actual provider-backed allocation.